### PR TITLE
Add configuration to separate integration-tests from unit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,53 @@
 
     <build>
         <plugins>
+            <!-- for unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.11</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.12</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <includes>
+                        <include>**/*.class</include>
+                    </includes>
+                    <excludedGroups>com.realkinetic.app.gabby.base.IntegrationTest</excludedGroups>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.12</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.12</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <groups>com.realkinetic.app.gabby.base.IntegrationTest</groups>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*.class</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/test/java/com/realkinetic/app/gabby/base/IntegrationTest.java
+++ b/src/test/java/com/realkinetic/app/gabby/base/IntegrationTest.java
@@ -1,0 +1,3 @@
+package com.realkinetic.app.gabby.base;
+
+public interface IntegrationTest {}

--- a/src/test/java/com/realkinetic/app/gabby/repository/downstream/google/pubsub/GooglePubsubDownstreamTest.java
+++ b/src/test/java/com/realkinetic/app/gabby/repository/downstream/google/pubsub/GooglePubsubDownstreamTest.java
@@ -1,7 +1,6 @@
 package com.realkinetic.app.gabby.repository.downstream.google.pubsub;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import com.realkinetic.app.gabby.base.IntegrationTest;
 import com.realkinetic.app.gabby.config.BaseConfig;
 import com.realkinetic.app.gabby.config.DefaultConfig;
 import com.realkinetic.app.gabby.config.GooglePubsubConfig;
@@ -14,14 +13,15 @@ import io.reactivex.observers.TestObserver;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+@Category(IntegrationTest.class)
 public class GooglePubsubDownstreamTest extends BaseDownstream {
     private static final Logger LOG = Logger.getLogger(GooglePubsubDownstreamTest.class.getName());
     private static GooglePubsubDownstream pubsubDownstream;

--- a/src/test/java/com/realkinetic/app/gabby/repository/downstream/redis/RedisDownstreamTest.java
+++ b/src/test/java/com/realkinetic/app/gabby/repository/downstream/redis/RedisDownstreamTest.java
@@ -1,15 +1,18 @@
 package com.realkinetic.app.gabby.repository.downstream.redis;
 
+import com.realkinetic.app.gabby.base.IntegrationTest;
 import com.realkinetic.app.gabby.config.BaseConfig;
 import com.realkinetic.app.gabby.config.DefaultConfig;
 import com.realkinetic.app.gabby.config.RedisConfig;
 import com.realkinetic.app.gabby.repository.BaseDownstream;
 import com.realkinetic.app.gabby.repository.DownstreamSubscription;
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 
 import java.util.Collections;
 import java.util.logging.Logger;
 
+@Category(IntegrationTest.class)
 public class RedisDownstreamTest extends BaseDownstream {
     private static final Logger LOG = Logger.getLogger(RedisDownstreamTest.class.getName());
     private static RedisDownstream redisDownstream;


### PR DESCRIPTION
So we have a way to skip the pub/sub redis smoke tests.

@RealKinetic/devs 